### PR TITLE
Adds virtualenv setup script, corresponding gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 __pycache__
 pytestdebug.log
 *.pyc

--- a/virtualenv.sh
+++ b/virtualenv.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+venv_path=".venv"
+venv_activate="$venv_path/bin/activate"
+venv_deactivate="deactivate"
+
+# Create a brand-new virtualenv directory.
+rm -rf "$venv_path" && virtualenv "$venv_path"
+
+# Activate virtualenv within this process.
+#
+# Shellcheck wants to be able to source this file itself, but can't do so when
+# the path is created at runtime. Oh well.
+#
+# shellcheck disable=SC1090
+source "$venv_activate"
+
+# Install packages as needed.
+pip install "testinfra" "docker" "molecule"
+
+# Deactviate virtualenv within this process.
+"$venv_deactivate"
+
+# Tell the user what to do.
+echo ""
+echo "Virtualenv prepared and packages installed. Use '. $venv_activate' to get started and '$venv_deactivate' when finished."
+echo ""


### PR DESCRIPTION
- This avoids listing dev-only python packages in e.g. python-requirements.txt
  so that dependabot doesn't hassle us about them (dependabot is awesome,
  it just doesn't suit this use case and it's easy to prevent it this way).